### PR TITLE
Add MetaWorld environment integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ## DUSDi: Disentangled Unsupervised Skill Discovery for Efficient Hierarchical Reinforcement Learning (NeurIPS 2024)
 This codebase was modified based on [URLB](https://github.com/rll-research/url_benchmark).
+It supports multiple domains, including toy, MoMa2D, Particle, iGibson, and MetaWorld.
 
 
 ## Requirements

--- a/agent/dusdi_diayn.yaml
+++ b/agent/dusdi_diayn.yaml
@@ -99,3 +99,12 @@ training_params:
         step_count_threshold: 10
         skill_dim: 5
         nstep: 1
+    metaworld:
+        sac: true
+        init_temperature: 0.1
+        update_skill_every_step: 50
+        use_spectral_norm: false
+        critic_type: mask_unwt
+        step_count_threshold: 10
+        skill_dim: 10
+        nstep: 1

--- a/agent/partition_utils.py
+++ b/agent/partition_utils.py
@@ -5,51 +5,66 @@ import numpy as np
 # these values will be initialized upon agent creation, in utils.py
 SIMP_PAR = None
 USE_IMG = None
+METAWORLD_CFG = None
+
+
+def _get_metaworld_space_info(config):
+    from custom_env.metaworld_gym_env import get_metaworld_space_info
+
+    cfg = config if config is not None else METAWORLD_CFG
+    if cfg is None:
+        raise ValueError("MetaWorld configuration has not been initialised.")
+    return get_metaworld_space_info(cfg)
 
 
 def get_env_obs_act_dim(domain, env_config):
-	if domain == "particle":
-		obs_dim = 70
-		if env_config.particle.simplify_action_space:
-			action_dim = 20
-		else:
-			action_dim = 50
-	else:
-		obs_part, _, action_part = get_env_factorization(domain, 0, 0)
-		obs_dim = sum(obs_part)
-		action_dim = sum(action_part)
+    if domain == "particle":
+        obs_dim = 70
+        if env_config.particle.simplify_action_space:
+            action_dim = 20
+        else:
+            action_dim = 50
+    elif domain == "metaworld":
+        obs_dim, action_dim = _get_metaworld_space_info(env_config.metaworld)
+    else:
+        obs_part, _, action_part = get_env_factorization(domain, 0, 0)
+        obs_dim = sum(obs_part)
+        action_dim = sum(action_part)
 
-	return obs_dim, action_dim
+    return obs_dim, action_dim
+
 
 # legacy function, not actually useful (i.e. the factorization can be arbitrary)
 def get_env_factorization(domain, skill_dim, skill_channel):
-	if "moma2d" in domain:
-		obs_partition = [4, 4, 4, 2, 3, 1]  # base, arm, view, base, arm, view
-		action_partition = [2, 3, 1]  # base, arm, view
-	elif domain == "particle":
-		N = skill_channel
-		if USE_IMG:
-			obs_partition = [1]*N + [2]*N + [2]*N  # No longer have velocity
-		else:
-			obs_partition = [1]*N + [4]*N + [2]*N  # lm1-3, pos_vel1-3, lm1-3
-		if SIMP_PAR:
-			action_partition = [2]*N
-		else:
-			action_partition = [5]*N
+    if "moma2d" in domain:
+        obs_partition = [4, 4, 4, 2, 3, 1]  # base, arm, view, base, arm, view
+        action_partition = [2, 3, 1]  # base, arm, view
+    elif domain == "particle":
+        N = skill_channel
+        if USE_IMG:
+            obs_partition = [1] * N + [2] * N + [2] * N  # No longer have velocity
+        else:
+            obs_partition = [1] * N + [4] * N + [2] * N  # lm1-3, pos_vel1-3, lm1-3
+        if SIMP_PAR:
+            action_partition = [2] * N
+        else:
+            action_partition = [5] * N
+    elif domain == "igibson":
+        obs_partition = [3, 4, 3, 8, 7, 7, 2, 5, 1]
+        action_partition = [2, 2, 3, 3, 1]
+    elif domain == "wipe":
+        obs_partition = [96]
+        action_partition = [17]
+    elif domain == "metaworld":
+        obs_dim, action_dim = _get_metaworld_space_info(None)
+        obs_partition = [obs_dim]
+        action_partition = [action_dim]
+    else:
+        # For other domain, this is not implemented yet
+        raise NotImplementedError
 
-	elif domain == "igibson":
-		obs_partition = [3, 4, 3, 8, 7, 7, 2, 5, 1]
-		action_partition = [2, 2, 3, 3, 1]
-	elif domain == "wipe":
-		obs_partition = [96]
-		action_partition = [17]
-	else:
-		# For other domain, this is not implemented yet
-		raise NotImplementedError
-
-	skill_partition = [skill_dim] * skill_channel
-	return obs_partition, skill_partition, action_partition
-
+    skill_partition = [skill_dim] * skill_channel
+    return obs_partition, skill_partition, action_partition
 
 
 ###############################
@@ -58,71 +73,77 @@ def get_env_factorization(domain, skill_dim, skill_channel):
 
 # specifies how the diayn vector should be partitioned
 def get_domain_stats(domain, env_config):
-	FULLBOX = env_config.igibson.fullbox
-	sep_obj = env_config.igibson.sep_obj
-	N = env_config.particle.N
+    FULLBOX = env_config.igibson.fullbox
+    sep_obj = env_config.igibson.sep_obj
+    N = env_config.particle.N
 
-	config = env_config[domain]
+    config = env_config[domain]
 
-	if domain == "toy":
-		diayn_dim = 2
-		state_partition_points = [0, 1, 2]
-	elif domain == "igibson":
-		assert FULLBOX
-		assert not sep_obj
-		diayn_dim = 10
-		state_partition_points = [0, 3, 7, 10]
-	elif domain == "moma2d":
-		diayn_dim = 12
-		state_partition_points = [0, 4, 8, 12]
-	elif domain == "particle":
-		diayn_dim = N * 1
-		state_partition_points = list(range(0, diayn_dim+1))
-	else:
-		raise NotImplementedError
+    if domain == "toy":
+        diayn_dim = 2
+        state_partition_points = [0, 1, 2]
+    elif domain == "igibson":
+        assert FULLBOX
+        assert not sep_obj
+        diayn_dim = 10
+        state_partition_points = [0, 3, 7, 10]
+    elif domain == "moma2d":
+        diayn_dim = 12
+        state_partition_points = [0, 4, 8, 12]
+    elif domain == "particle":
+        diayn_dim = N * 1
+        state_partition_points = list(range(0, diayn_dim + 1))
+    elif domain == "metaworld":
+        obs_dim, _ = _get_metaworld_space_info(env_config.metaworld)
+        diayn_dim = getattr(env_config.metaworld, "diayn_dim", None)
+        if diayn_dim is None:
+            diayn_dim = obs_dim
+        state_partition_points = [0, diayn_dim]
+    else:
+        raise NotImplementedError
 
-	assert state_partition_points[-1] == diayn_dim
-	assert state_partition_points[0] == 0
+    assert state_partition_points[-1] == diayn_dim
+    assert state_partition_points[0] == 0
 
-	return diayn_dim, state_partition_points
+    return diayn_dim, state_partition_points
 
 
 # specifies how the diayn vector should be extracted from observation
 def observation_filter(obs, domain, env_config):
-	if obs is None:
-		return None
+    if obs is None:
+        return None
 
-	config = env_config[domain]
+    config = env_config[domain]
 
-	# We always process in batch
-	if len(obs.shape) == 1:
-		obs = obs.unsqueeze(0)
+    # We always process in batch
+    if len(obs.shape) == 1:
+        obs = obs.unsqueeze(0)
 
-	if domain == "toy":
-		return obs
-	elif domain == "igibson":
-		idx = np.array(range(10))
-		return obs[:, idx]
-	elif domain == "wipe":
-		idx = np.array(range(*config.diayn_idx))
-		return obs[:, idx]
-	elif domain == "moma2d":
-		idx = np.array(range(12))
-		return obs[:, idx]
-	elif domain == "particle":
-		idx = np.array(range(env_config.particle.N))
-		return obs[:, idx]
-	else:
-		print("Domain {} not supported".format(domain))
-		raise NotImplementedError
+    if domain == "toy":
+        return obs
+    elif domain == "igibson":
+        idx = np.array(range(10))
+        return obs[:, idx]
+    elif domain == "wipe":
+        idx = np.array(range(*config.diayn_idx))
+        return obs[:, idx]
+    elif domain == "moma2d":
+        idx = np.array(range(12))
+        return obs[:, idx]
+    elif domain == "particle":
+        idx = np.array(range(env_config.particle.N))
+        return obs[:, idx]
+    else:
+        print("Domain {} not supported".format(domain))
+        raise NotImplementedError
 
 
 # This function is used for partitioning input into different parts
 def obtain_partitions(obs, skill, action, domain, skill_dim, skill_channel):
-	obs_partition, skill_partition, action_partition = get_env_factorization(domain, skill_dim, skill_channel)
-	# Next, partition both the obs and the skill
-	skill_list = torch.split(skill, skill_partition, dim=-1)
-	obs_list = torch.split(obs, obs_partition, dim=-1)
-	action_list = torch.split(action, action_partition, dim=-1)
+    obs_partition, skill_partition, action_partition = get_env_factorization(domain, skill_dim, skill_channel)
+    # Next, partition both the obs and the skill
+    skill_list = torch.split(skill, skill_partition, dim=-1)
+    obs_list = torch.split(obs, obs_partition, dim=-1)
+    action_list = torch.split(action, action_partition, dim=-1)
 
-	return obs_list, skill_list, action_list
+    return obs_list, skill_list, action_list

--- a/custom_env/metaworld_gym_env.py
+++ b/custom_env/metaworld_gym_env.py
@@ -1,0 +1,225 @@
+"""MetaWorld environment wrappers for DUSDi.
+
+This module provides a gym-compatible environment that exposes MetaWorld
+benchmarks with a consistent API for the rest of the codebase. It also
+contains helper utilities for building environments from a Hydra
+configuration and for inferring the observation/action dimensions.
+"""
+
+from typing import Dict, List, Optional, Sequence, Tuple
+
+import gym
+from gym import spaces
+import numpy as np
+from omegaconf import OmegaConf
+
+import metaworld
+
+
+def _to_float_box(space: spaces.Box) -> spaces.Box:
+    """Convert a Box space to float32 while preserving bounds."""
+    low = np.array(space.low, dtype=np.float32)
+    high = np.array(space.high, dtype=np.float32)
+    return spaces.Box(low=low, high=high, dtype=np.float32)
+
+
+def _flatten_observation(obs: np.ndarray | Dict[str, np.ndarray],
+                         keys: Optional[Sequence[str]] = None) -> np.ndarray:
+    """Flatten dictionary observations into a single float32 vector."""
+    if isinstance(obs, dict):
+        if keys is None:
+            items = obs.items()
+        else:
+            items = ((key, obs[key]) for key in keys)
+        pieces: List[np.ndarray] = []
+        for _, value in items:
+            if isinstance(value, (list, tuple)):
+                value = np.asarray(value)
+            pieces.append(np.asarray(value, dtype=np.float32).ravel())
+        obs_array = np.concatenate(pieces, axis=0)
+    else:
+        obs_array = np.asarray(obs, dtype=np.float32).ravel()
+    return obs_array.astype(np.float32)
+
+
+class MetaWorldGymEnv(gym.Env):
+    """Wrap MetaWorld tasks to expose a standard gym interface."""
+
+    metadata = {"render.modes": ["human", "rgb_array"]}
+
+    def __init__(self,
+                 suite: str,
+                 task: str,
+                 mode: str = "train",
+                 max_episode_steps: Optional[int] = None,
+                 randomize_task_on_reset: bool = True,
+                 obs_keys: Optional[Sequence[str]] = None,
+                 obs_clip: Optional[float] = None,
+                 seed: Optional[int] = None) -> None:
+        super().__init__()
+
+        self.suite = suite.upper()
+        self.task_name = task
+        self.mode = mode
+        self.randomize_task_on_reset = randomize_task_on_reset
+        self.obs_keys = tuple(obs_keys) if obs_keys is not None else None
+        self.obs_clip = obs_clip
+        self._rng = np.random.RandomState()
+
+        benchmark = self._build_benchmark()
+        self._tasks, env_cls = self._resolve_tasks(benchmark)
+        if len(self._tasks) == 0:
+            raise ValueError(f"No MetaWorld tasks found for '{self.task_name}' in suite '{self.suite}'.")
+
+        self._env = env_cls()
+        if seed is not None:
+            self.seed(seed)
+        if hasattr(self._env, "max_path_length"):
+            default_horizon = int(self._env.max_path_length)
+        else:
+            default_horizon = 200
+        self.max_episode_steps = max_episode_steps or default_horizon
+        self._step_count = 0
+        self._last_success = 0.0
+
+        self.action_space = _to_float_box(self._env.action_space)
+        if not isinstance(self._env.observation_space, spaces.Box):
+            raise ValueError("MetaWorld environments are expected to expose Box observation spaces.")
+        self.observation_space = _to_float_box(self._env.observation_space)
+
+        self._current_task_index = 0
+        self._select_task()
+
+    # ---------------------------------------------------------------------
+    # Benchmark construction helpers
+    # ---------------------------------------------------------------------
+    def _build_benchmark(self):
+        if self.suite == "ML1":
+            return metaworld.ML1(self.task_name)
+        if self.suite == "MT1":
+            return metaworld.MT1(self.task_name)
+        if self.suite == "ML45":
+            return metaworld.ML45()
+        if self.suite == "MT10":
+            return metaworld.MT10()
+        if self.suite == "MT50":
+            return metaworld.MT50()
+        raise ValueError(f"Unsupported MetaWorld suite '{self.suite}'.")
+
+    def _resolve_tasks(self, benchmark) -> Tuple[Sequence, type]:
+        if self.suite in {"ML1", "MT1"}:
+            if self.mode == "train":
+                task_pool = benchmark.train_tasks
+                class_pool = benchmark.train_classes
+            else:
+                task_pool = benchmark.test_tasks
+                class_pool = benchmark.test_classes
+            env_cls = class_pool[self.task_name]
+            tasks = [task for task in task_pool if task.env_name == self.task_name]
+        else:
+            if self.mode == "train":
+                task_pool = benchmark.train_tasks
+                class_pool = benchmark.train_classes
+            else:
+                task_pool = benchmark.test_tasks
+                class_pool = benchmark.test_classes
+            if self.task_name not in class_pool:
+                raise ValueError(f"Task '{self.task_name}' is not part of suite '{self.suite}'.")
+            env_cls = class_pool[self.task_name]
+            tasks = [task for task in task_pool if task.env_name == self.task_name]
+        return tasks, env_cls
+
+    # ------------------------------------------------------------------
+    # gym.Env interface
+    # ------------------------------------------------------------------
+    def seed(self, seed: Optional[int] = None) -> Sequence[int]:
+        self._rng.seed(seed)
+        if hasattr(self._env, "seed"):
+            self._env.seed(seed)
+        return [seed] if seed is not None else []
+
+    def _select_task(self) -> None:
+        if not self._tasks:
+            return
+        if self.randomize_task_on_reset:
+            self._current_task_index = int(self._rng.randint(len(self._tasks)))
+        task = self._tasks[self._current_task_index]
+        self._env.set_task(task)
+
+    def reset(self):  # type: ignore[override]
+        self._step_count = 0
+        self._last_success = 0.0
+        self._select_task()
+        obs = self._env.reset()
+        return self._process_observation(obs)
+
+    def step(self, action):  # type: ignore[override]
+        obs, reward, done, info = self._env.step(action)
+        self._step_count += 1
+        success = float(info.get("success", info.get("Success", 0.0)))
+        self._last_success = success
+        if self._step_count >= self.max_episode_steps:
+            done = True
+        processed_obs = self._process_observation(obs)
+        info = dict(info)
+        info["success"] = success
+        return processed_obs, float(reward), bool(done), info
+
+    def render(self, mode: str = "human"):
+        return self._env.render(mode)
+
+    def close(self):  # type: ignore[override]
+        if hasattr(self._env, "close"):
+            self._env.close()
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _process_observation(self, obs):
+        obs_array = _flatten_observation(obs, self.obs_keys)
+        if self.obs_clip is not None:
+            np.clip(obs_array, -self.obs_clip, self.obs_clip, out=obs_array)
+        return obs_array
+
+    def get_additional_states(self) -> np.ndarray:
+        progress = self._step_count / float(self.max_episode_steps)
+        return np.array([progress, self._last_success], dtype=np.float32)
+
+
+def _config_to_dict(cfg) -> Dict[str, object]:
+    if OmegaConf.is_config(cfg):
+        return OmegaConf.to_container(cfg, resolve=True)  # type: ignore[return-value]
+    if isinstance(cfg, dict):
+        return dict(cfg)
+    raise TypeError("Unsupported configuration type for MetaWorld environment.")
+
+
+def create_metaworld_env_from_cfg(cfg,
+                                  task: Optional[str] = None,
+                                  mode: Optional[str] = None,
+                                  seed: Optional[int] = None) -> MetaWorldGymEnv:
+    cfg_dict = _config_to_dict(cfg)
+    task_name = task or cfg_dict.get("task")
+    if task_name is None:
+        raise ValueError("MetaWorld configuration must define a 'task'.")
+    env = MetaWorldGymEnv(
+        suite=cfg_dict.get("suite", "ML1"),
+        task=task_name,
+        mode=mode or cfg_dict.get("mode", "train"),
+        max_episode_steps=cfg_dict.get("episode_length"),
+        randomize_task_on_reset=cfg_dict.get("randomize_task_on_reset", True),
+        obs_keys=cfg_dict.get("obs_keys"),
+        obs_clip=cfg_dict.get("obs_clip"),
+        seed=seed,
+    )
+    return env
+
+
+def get_metaworld_space_info(cfg,
+                             task: Optional[str] = None,
+                             mode: Optional[str] = None) -> Tuple[int, int]:
+    env = create_metaworld_env_from_cfg(cfg, task=task, mode=mode)
+    obs_dim = int(np.prod(env.observation_space.shape))
+    action_dim = int(np.prod(env.action_space.shape))
+    env.close()
+    return obs_dim, action_dim

--- a/env/env_config.yaml
+++ b/env/env_config.yaml
@@ -15,3 +15,14 @@ particle:
 igibson:
   fullbox: true  # whether to use x & y of the box for classification
   sep_obj: false  # whether to separate objects
+
+metaworld:
+  suite: ML1
+  task: reach-v2
+  mode: train
+  ds_mode: test
+  episode_length: 200
+  randomize_task_on_reset: true
+  obs_keys: null
+  obs_clip: null
+  diayn_dim: null

--- a/env/env_list.py
+++ b/env/env_list.py
@@ -1,6 +1,6 @@
 """record supports for each env"""
 
-rv_list = ["moma2d", "particle"] 	# whether we can record video (i.e. gif)
-plot_prediction_list = ["toy", "particle", "moma2d", "particle"]	# whether we can plot prediction net
-no_video_eval_list = ["toy", "particle", "moma2d", "particle"]	# whether we want to save gif during evaluation
-save_image_eval_list = ["toy", "moma2d"]	# whether we want to save image during evaluation
+rv_list = ["moma2d", "particle", "metaworld"]  # whether we can record video (i.e. gif)
+plot_prediction_list = ["toy", "particle", "moma2d", "particle"]  # whether we can plot prediction net
+no_video_eval_list = ["toy", "particle", "moma2d", "particle"]  # whether we want to save gif during evaluation
+save_image_eval_list = ["toy", "moma2d"]  # whether we want to save image during evaluation

--- a/env_helper.py
+++ b/env_helper.py
@@ -109,6 +109,12 @@ def get_single_gym_env(cfg, rank=0):
             physics_timestep=physics_timestep,
         )
         env.seed(cfg.seed + rank)
+    elif cfg.domain == "metaworld":
+        from custom_env.metaworld_gym_env import create_metaworld_env_from_cfg
+
+        env = create_metaworld_env_from_cfg(cfg.env.metaworld,
+                                            seed=cfg.seed + rank,
+                                            mode=getattr(cfg.env.metaworld, "mode", "train"))
     else:
         raise NotImplementedError
 
@@ -235,6 +241,23 @@ def make_ds_envs(cfg, actor, device):
 
         return make_igibson_downstream_env
 
+    elif cfg.domain == "metaworld":
+        from custom_env.metaworld_gym_env import create_metaworld_env_from_cfg
+
+        low_level_step = getattr(cfg.agent, "update_skill_every_step",
+                                 cfg.agent.training_params[cfg.domain].update_skill_every_step)
+
+        def make_metaworld_ds_env(vis=False):
+            task_name = getattr(cfg, "ds_task", None) or cfg.env.metaworld.task
+            ds_mode = getattr(cfg.env.metaworld, "ds_mode", getattr(cfg.env.metaworld, "mode", "train"))
+            env = create_metaworld_env_from_cfg(cfg.env.metaworld,
+                                                task=task_name,
+                                                mode=ds_mode,
+                                                seed=cfg.seed)
+            env = wrap_ds_env(env, cfg, actor, device, low_level_step, vis)
+            return env
+
+        return make_metaworld_ds_env
     else:
         assert NotImplementedError
 

--- a/pretrain.yaml
+++ b/pretrain.yaml
@@ -35,7 +35,7 @@ update_ratio: 2 # how many env steps per update
 n_env: 4
 
 # task settings
-domain: particle # toy # igibson # moma2d # particle
+domain: particle # toy # igibson # moma2d # particle # metaworld
 
 exp_nm: ""
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ dm-control
 termcolor
 einops
 dm-env==1.6
+metaworld

--- a/train.py
+++ b/train.py
@@ -125,6 +125,8 @@ class Workspace:
                 cfg.snapshot_ts = 100000
             elif domain == "moma2d":
                 cfg.agent.skill_dim = 125
+            elif domain == "metaworld":
+                cfg.agent.skill_dim = cfg.agent.training_params[domain].skill_dim
             else:
                 raise NotImplementedError
 

--- a/train.yaml
+++ b/train.yaml
@@ -5,7 +5,7 @@ defaults:
 # mode
 reward_free: false
 # task settings
-domain: particle # toy #
+domain: particle # toy # metaworld
 obs_type: states # [states, pixels]
 frame_stack: 3 # only works if obs_type=pixels
 action_repeat: 1 # set to 2 for pixels

--- a/utils.py
+++ b/utils.py
@@ -323,6 +323,8 @@ def update_partition_config(cfg):
     import agent.partition_utils
     agent.partition_utils.SIMP_PAR = cfg.env_config.particle.simplify_action_space
     agent.partition_utils.USE_IMG = cfg.env_config.particle.use_img
+    if hasattr(cfg.env_config, "metaworld"):
+        agent.partition_utils.METAWORLD_CFG = cfg.env_config.metaworld
 
 def make_agent(obs_type, obs_spec, action_spec, num_expl_steps, parent_cfg, cfg):
     cfg.obs_type = obs_type


### PR DESCRIPTION
## Summary
- add a MetaWorld gym wrapper and utilities for creating environments from Hydra configs
- extend environment helpers, configuration, and agent utilities to recognize the new MetaWorld domain
- document MetaWorld support and declare the extra dependency in the requirements

## Testing
- python -m compileall custom_env/metaworld_gym_env.py env_helper.py agent/partition_utils.py utils.py train.py

------
https://chatgpt.com/codex/tasks/task_e_68d5ec34c9e88326abe90059e12a3e71